### PR TITLE
adding get node version

### DIFF
--- a/workflow-templates/fluent-linter.yml
+++ b/workflow-templates/fluent-linter.yml
@@ -1,6 +1,10 @@
 name: Fluent linter 
 
-on: pull_request
+on:
+push:
+    branches:
+      - main
+pull_request:
 
 jobs:
   lint:

--- a/workflow-templates/get_node_version.json
+++ b/workflow-templates/get_node_version.json
@@ -1,0 +1,5 @@
+{
+  "name": "Get node version from nvmrc",
+  "description": "This reusable workflow will retrieve node version from any package",
+  "categories": ["node, nodejs, nvmrc, version"]
+}

--- a/workflow-templates/get_node_version.yml
+++ b/workflow-templates/get_node_version.yml
@@ -1,0 +1,27 @@
+name: Get node version
+
+on:
+  workflow_call:
+    inputs:
+      nvmrc_location:
+        description: "nvmrc location, by default located at the repository's root"
+        type: string
+        required: false
+        default: '.nvmrc'
+    outputs:
+      node_version:
+        description: 'node version obtained'
+        value: ${{ jobs.setNodeVersion.outputs.NODE_VERSION }}
+
+jobs:
+  setNodeVersion:
+    runs-on: ubuntu-latest
+    outputs:
+      NODE_VERSION: ${{ steps.getVersion.outputs.NODE_VERSION }}
+    steps:
+      - uses: actions/checkout@main
+      - name: Reading ${{ inputs.nvmrc_location }}
+        id: getVersion
+        run: echo "##[set-output name=NODE_VERSION;]$(cat ${{ inputs.nvmrc_location }})"
+      - name: version found ${{ steps.getVersion.outputs.NODE_VERSION }}
+        run: echo ${{ steps.getVersion.outputs.NODE_VERSION }}


### PR DESCRIPTION
Adding a handy workflow so we can re-use it among different `nodejs` based repositories when running workflows. 

a typical use of this workflow would look like

let's say we wish to run linting on a given package:

```yml

name: Lint

on:
  push:
    branches:
      - main
  pull_request:

jobs:
  getNodeVersion:
    uses: calyptia/.github/workflow_templates/get_node_version.yml@main

  lint:
    runs-on: ubuntu-latest
    needs: getNodeVersion
    steps:
      - uses: actions/checkout@main
      - name: Setting node version to ${{ needs.getNodeVersion.outputs.node_version }}
        uses: actions/setup-node@v2
        with:
          node-version: '${{ needs.getNodeVersion.outputs.node_version }}'
      - run: npm install
      - run: npm run lint
```

I've also added  events to fluent-linter.yml workflow to make it trigger on push as well. 