### PR TITLE
exposing workflows as reusable

### DIFF
--- a/.github/workflows/get_node_version.yml
+++ b/.github/workflows/get_node_version.yml
@@ -1,0 +1,27 @@
+name: Get node version
+
+on:
+  workflow_call:
+    inputs:
+      nvmrc_location:
+        description: "nvmrc location, by default located at the repository's root"
+        type: string
+        required: false
+        default: '.nvmrc'
+    outputs:
+      node_version:
+        description: 'node version obtained'
+        value: ${{ jobs.setNodeVersion.outputs.NODE_VERSION }}
+
+jobs:
+  setNodeVersion:
+    runs-on: ubuntu-latest
+    outputs:
+      NODE_VERSION: ${{ steps.getVersion.outputs.NODE_VERSION }}
+    steps:
+      - uses: actions/checkout@main
+      - name: Reading ${{ inputs.nvmrc_location }}
+        id: getVersion
+        run: echo "##[set-output name=NODE_VERSION;]$(cat ${{ inputs.nvmrc_location }})"
+      - name: version found ${{ steps.getVersion.outputs.NODE_VERSION }}
+        run: echo ${{ steps.getVersion.outputs.NODE_VERSION }}


### PR DESCRIPTION
Workflows can only be used as a template when located under `workflows-templates`

![image](https://user-images.githubusercontent.com/226559/148742035-b819636b-f13e-49d6-9afd-e8b2e4a0cccc.png)

so copying the reusable ones to `.github/workflows/` as well. 